### PR TITLE
Add the `mcl` command to go back to last directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # mchdir <!-- omit in toc -->
 
-A utility for creating a new folder then changing into it in one command, or
-creating and changing into a temporary folder.
+A utility for creating a new folder then changing into it in one command,
+changing to the last remembered directory or creating and changing into a
+temporary folder.
 
 Written in Rust and using shell integration.
 
@@ -23,6 +24,7 @@ Written in Rust and using shell integration.
 - [Usage](#usage)
   - [`mcd` Command](#mcd-command)
   - [`mct` Command](#mct-command)
+  - [`mcl` Command](#mcl-command)
   - [mchdir Command](#mchdir-command)
 - [License](#license)
 - [Contributing](#contributing)
@@ -31,8 +33,8 @@ Written in Rust and using shell integration.
 
 `mchdir` is a command-line tool written in Rust that allows you to create a new
 directory and immediately change into it. It includes shell integration that
-defines an mcd command in your shell, simplifying directory creation and
-navigation.
+defines an a couple of helpfull commands in your shell, simplifying directory
+creation and navigation.
 
 Documentation is available at
 [https://seapagan.github.io/mchdir/](https://seapagan.github.io/mchdir/).
@@ -46,8 +48,8 @@ on Linux/macOS.
 
 It's true that you can do the same thing with a simple shell function or alias!
 However, this project is a demonstration of how to create a command-line tool in
-Rust that provides shell integration. It will also probably get more features in
-the future.
+Rust that provides (and installs!) shell integration. It will also probably get
+more features in the future.
 
 ### Why the need for shell integration too?
 
@@ -60,9 +62,11 @@ of the shell that runs it without shell integration.
 ## Features
 
 - Create a new directory and change into it with a single command.
-- Create a new directory in the system temporary directory and change into it with the `mct` command.
+- Create a new directory in the system temporary directory and change into it
+  with the `mct` command.
+- Change back to the last directory with the `mcl` command.
 - Shell integration for bash, zsh, and fish shells as first-class citizens,
-  while it should work in most POSIX-compliant shells too.
+  though it should work in most POSIX-compliant shells too.
 - Supports automatic installation of shell integration scripts.
 
 ## Installation
@@ -263,6 +267,27 @@ Output:
 Usage: mct <directory>
     Creates a new directory in the system temporary directory and changes into it.
     If no directory is specified, creates a random directory in the temp folder.
+```
+
+### `mcl` Command
+
+- Changes to the previous directory the shell was in:
+
+  ```terminal
+  mcl
+  ```
+
+- Display help for the `mcl` command:
+
+  ```terminal
+  mcl --help
+  ```
+
+Output:
+
+```terminal
+Usage: mcl
+  Changes to the previous directory the shell was in.
 ```
 
 ### mchdir Command

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Written in Rust and using shell integration.
 
 `mchdir` is a command-line tool written in Rust that allows you to create a new
 directory and immediately change into it. It includes shell integration that
-defines an a couple of helpfull commands in your shell, simplifying directory
+defines an a couple of helpful commands in your shell, simplifying directory
 creation and navigation.
 
 Documentation is available at
@@ -61,7 +61,7 @@ of the shell that runs it without shell integration.
 
 ## Features
 
-- Create a new directory and change into it with a single command.
+- Create a new directory and change into it with a single command (`mcd`).
 - Create a new directory in the system temporary directory and change into it
   with the `mct` command.
 - Change back to the last directory with the `mcl` command.
@@ -126,8 +126,8 @@ cargo install --git https://github.com/seapagan/mchdir.git
 
 ## Shell Integration
 
-To enable the mcd and mct commands in your shell, you need to integrate `mchdir` with
-your shell configuration.
+To enable the `mcd`, `mcl` and `mct` commands in your shell, you need to
+integrate `mchdir` with your shell configuration.
 
 ### Automatic Installation
 
@@ -249,7 +249,8 @@ If no directory is specified, changes to the home directory.
   mct my_temp_directory
   ```
 
-- Create a truly random directory in the system temporary directory and change into it (when no argument is provided):
+- Create a truly random directory in the system temporary directory and change
+  into it (when no argument is provided):
 
   ```terminal
   mct
@@ -282,13 +283,6 @@ Usage: mct <directory>
   ```terminal
   mcl --help
   ```
-
-Output:
-
-```terminal
-Usage: mcl
-  Changes to the previous directory the shell was in.
-```
 
 ### mchdir Command
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -9,4 +9,4 @@ title = "Mchdir Documentation"
 create-missing = true
 
 [output.html]
-default-theme = "light"
+default-theme = "rust"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,4 +7,3 @@
 - [Shell Integration](./shell_integration.md)
 - [Usage](./usage.md)
 - [License](./license.md)
-- [Contributing](./contributing.md)

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,5 +1,0 @@
-
-# Contributing
-
-Contributions are welcome! Please open an issue or submit a pull request on
-GitHub.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,8 +1,9 @@
 
 # Installation
 
-To install `mchdir`, you can use crates.io, build it from source, or install it
-directly from GitHub.
+In the future, there will be pre-built binaries available for download, but for
+now you can use crates.io, build it from source, or install it directly from
+GitHub.
 
 ## Prerequisites
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -3,8 +3,8 @@
 
 `mchdir` is a command-line tool written in Rust that allows you to create a new
 directory and immediately change into it. It includes shell integration that
-defines an `mcd` command in your shell, simplifying directory creation and
-navigation.
+defines an a couple of helpful commands in your shell, simplifying directory
+creation and navigation.
 
 ## Description
 
@@ -36,8 +36,15 @@ of the shell that runs it without shell integration.
 
 ## Features
 
-- Create a new directory and change into it with a single command.
+- Create a new directory and change into it with a single command (`mcd`).
 - Create a new directory in the system temporary directory and change into it
   with the `mct` command.
-- Shell integration for bash, zsh, and fish shells.
+- Change back to the last directory with the `mcl` command.
+- Shell integration for bash, zsh, and fish shells as first-class citizens,
+  though it should work in most POSIX-compliant shells too.
 - Supports automatic installation of shell integration scripts.
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request on
+GitHub.

--- a/docs/src/shell_integration.md
+++ b/docs/src/shell_integration.md
@@ -1,8 +1,8 @@
 
 # Shell Integration
 
-To enable the `mcd` and `mct` commands in your shell, you need to integrate
-`mchdir` with your shell configuration.
+To enable the `mcd`, `mcl` and `mct` commands in your shell, you need to
+integrate `mchdir` with your shell configuration.
 
 ## Automatic Installation
 
@@ -37,3 +37,7 @@ Add the following code to your `~/.config/fish/config.fish` file:
 ```bash
 eval (mchdir init)
 ```
+
+> Note that after shell integration, you should no longer need to run the
+> `mchdir` command again, unless you need to reinstall the shell integration. It
+> DOES need to remain in your PATH for the shell integration to work however.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -31,7 +31,8 @@ After installing `mchdir`, use the following commands:
   mct my_temp_directory
   ```
 
-- Create a truly random directory in the system temporary directory:
+- Create a truly random directory in the system temporary directory and change
+  into it:
 
   ```bash
   mct
@@ -41,6 +42,20 @@ After installing `mchdir`, use the following commands:
 
   ```bash
   mct --help
+  ```
+
+## `mcl` Command
+
+- Changes to the previous directory the shell was in:
+
+  ```terminal
+  mcl
+  ```
+
+- Display help for the `mcl` command:
+
+  ```terminal
+  mcl --help
   ```
 
 ## `mchdir` Command


### PR DESCRIPTION
Uses the `$OLDPWD` env variable to detect and switch to the last visited folder.